### PR TITLE
rm node6 saupport due to async await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - osx
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 'test-{build}'
 environment:
   matrix:
-    - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
 platform:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "name": "iobroker.harmony",
     "version": "1.1.0",
+    "engines": {
+        "node": ">=8.0.0"
+    },
     "description": "Control your harmony activities from ioBroker.",
     "author": "Pmant <patrickmo@gmx.de>",
     "contributors": [],


### PR DESCRIPTION
- due to the usage of async await we should prevent installation with node < 8 
- also tests can be removed