### PR TITLE
 reduce discover interval and only log newly discovered hubs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
         "prefer-const": "error",
         "quotes": [
             "error",
-            "single",
+            "backtick",
             {
                 "avoidEscape": true,
                 "allowTemplateLiterals": true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Pmant <patrickmo@gmx.de>
+Copyright (c) 2015-2019 Pmant <patrickmo@gmx.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ A value smaller than 250 probably will send the command only once.
 After sending the state will be set to 0 again.
 
 ## Changelog
+### 1.2.2 (2019-03-11)
+* (foxriver76) reduce discover interval and only log newly discovered hubs
+
 ### 1.2.1 (2019-02-21)
 * (foxriver76) use at least 1.0.5 of harmonyhubws 
 

--- a/harmony.js
+++ b/harmony.js
@@ -9,14 +9,14 @@
 /*jslint node: true */
 'use strict';
 
-const HarmonyHubDiscover = require('@harmonyhub/discover').Explorer;
-const utils = require('@iobroker/adapter-core');
-const HarmonyWS = require('harmonyhubws');
+const HarmonyHubDiscover = require(`@harmonyhub/discover`).Explorer;
+const utils = require(`@iobroker/adapter-core`);
+const HarmonyWS = require(`harmonyhubws`);
 const hubs = {};
 let adapter;
 let discover;
 const FORBIDDEN_CHARS = /[\][*,;'"`<>\\? ]/g;
-const fixId = (id) => id.replace(FORBIDDEN_CHARS, '_');
+const fixId = (id) => id.replace(FORBIDDEN_CHARS, `_`);
 let manualDiscoverHubs;
 let subnet;
 let discoverInterval;
@@ -25,23 +25,23 @@ let discoverInterval;
 function startAdapter(options) {
     options = options || {};
     Object.assign(options, {
-        name: 'harmony'
+        name: `harmony`
     });
     adapter = new utils.Adapter(options);
 
-    adapter.on('stateChange', (id, state) => {
+    adapter.on(`stateChange`, (id, state) => {
         if (!id || !state || state.ack) {
             return;
         }
-        const hub = id.split('.')[2];
+        const hub = id.split(`.`)[2];
         if (!hubs[hub]) return;
         const semaphore = hubs[hub].semaphore;
         if (semaphore === undefined) {
-            adapter.log.warn('state changed in offline hub');
+            adapter.log.warn(`state changed in offline hub`);
             return;
         }
         if (semaphore.current > 0) {
-            adapter.log.info('hub busy, stateChange delayed: ' + id + '=' + state.val);
+            adapter.log.info(`hub busy, stateChange delayed: ${id} = ${state.val}`);
         }
         semaphore.take(() => {
             setBlocked(hub, true);
@@ -55,9 +55,9 @@ function startAdapter(options) {
     });
 
     // callback has to be called under any circumstances
-    adapter.on('unload', callback => {
+    adapter.on(`unload`, callback => {
         try {
-            adapter.log.info('[END] Terminating');
+            adapter.log.info(`[END] Terminating`);
             if (discover) {
                 discover.stop();
             } // endIf
@@ -71,7 +71,7 @@ function startAdapter(options) {
         } // endTryCatch
     });
 
-    adapter.on('ready', () => {
+    adapter.on(`ready`, () => {
         main();
     });
 
@@ -79,24 +79,24 @@ function startAdapter(options) {
 } // endStartAdapter
 
 function processStateChange(hub, id, state, callback) {
-    const tmp = id.split('.');
-    let channel = '';
-    let name = '';
+    const tmp = id.split(`.`);
+    let channel = ``;
+    let name = ``;
     if (tmp.length === 5) {
         name = tmp.pop();
         channel = tmp.pop();
     } else {
-        adapter.log.warn('unknown state change');
+        adapter.log.warn(`unknown state change`);
         return;
     }
     switch (channel) {
-        case 'activities':
+        case `activities`:
             switch (name) {
-                case 'currentStatus':
+                case `currentStatus`:
                     switchActivity(hub, undefined, 0, callback);
                     break;
-                case 'currentActivity':
-                    adapter.log.warn('change activities, not currentActivity');
+                case `currentActivity`:
+                    adapter.log.warn(`change activities, not currentActivity`);
                     callback();
                     break;
                 default:
@@ -105,7 +105,7 @@ function processStateChange(hub, id, state, callback) {
             }
             break;
         default:
-            adapter.log.debug('sending command: ' + channel + ':' + name);
+            adapter.log.debug(`sending command: ${channel}:${name}`);
             if (state.val) {
                 let ms = parseInt(state.val);
                 if (isNaN(ms) || ms < 100) {
@@ -123,25 +123,25 @@ function processStateChange(hub, id, state, callback) {
 function sendCommand(hub, id, ms, callback) {
     adapter.getObject(id, function (err, obj) {
         if (err) {
-            adapter.log.warn('cannot send command, unknown state');
+            adapter.log.warn(`cannot send command, unknown state`);
             adapter.setState(id, {val: 0, ack: true});
             callback();
             return;
         }
         if (!hubs[hub].client || hubs[hub].client.status !== 3) {
-            adapter.log.warn('error sending command, client offline');
+            adapter.log.warn(`error sending command, client offline`);
             adapter.setState(id, {val: 0, ack: true});
             callback();
             return;
         }
-        adapter.log.debug('sending command: ' + obj.common.name);
+        adapter.log.debug(`sending command: ${obj.common.name}`);
 
         if (ms <= 250) {
             hubs[hub].client.requestKeyPress(obj.native.action, 100);
             adapter.setState(id, {val: 0, ack: true});
             callback();
         } else {
-            hubs[hub].client.requestKeyPress(obj.native.action, 'hold', ms);
+            hubs[hub].client.requestKeyPress(obj.native.action, `hold`, ms);
             setTimeout(() => {
                 adapter.setState(id, {val: 0, ack: true});
                 callback();
@@ -155,7 +155,7 @@ function switchActivity(hub, activityLabel, value, callback) {
     //  of after hub has confirmed that the activity has been changed). So we should just block hub before
     //  calling switchActivity and unblock on receiving changed activity in listener maybe in setStatusFromActivityID
     if (!hubs[hub].client) {
-        adapter.log.warn('[ACTIVITY] Error changing activity, client offline');
+        adapter.log.warn(`[ACTIVITY] Error changing activity, client offline`);
         callback();
         return;
     }
@@ -163,70 +163,71 @@ function switchActivity(hub, activityLabel, value, callback) {
     value = parseInt(value);
     if (isNaN(value)) value = 1;
     if (value === 0) {
-        adapter.log.debug('[ACTIVITY] Turning activity off');
-        hubs[hub].client.requestActivityChange('-1').then(callback);
+        adapter.log.debug(`[ACTIVITY] Turning activity off`);
+        hubs[hub].client.requestActivityChange(`-1`).then(callback);
     } else if (hubs[hub].activities_reverse.hasOwnProperty(activityLabel)) {
-        adapter.log.debug('[ACTIVITY] Switching activity to: ' + activityLabel);
+        adapter.log.debug(`[ACTIVITY] Switching activity to: ${activityLabel}`);
         hubs[hub].client.requestActivityChange(hubs[hub].activities_reverse[activityLabel]).then(callback);
     } else {
-        adapter.log.warn('[ACTIVITY] Activity does not exists');
+        adapter.log.warn(`[ACTIVITY] Activity does not exists`);
         callback();
     }
 }
 
 function main() {
     manualDiscoverHubs = adapter.config.devices || [];
-    subnet = adapter.config.subnet || '255.255.255.255';
+    subnet = adapter.config.subnet || `255.255.255.255`;
     discoverInterval = adapter.config.discoverInterval || 1000;
-    adapter.subscribeStates('*');
-    adapter.log.debug('[START] Subnet: ' + subnet + ', Discovery interval: ' + discoverInterval);
+    adapter.subscribeStates(`*`);
+    adapter.log.debug(`[START] Subnet: ${subnet}, Discovery interval: ${discoverInterval}`);
     discoverStart();
 }
 
 function discoverStart() {
     if (discover) {
-        adapter.log.debug('[DISCOVER] Discover already started');
+        adapter.log.debug(`[DISCOVER] Discover already started`);
         return;
     } // endIf
 
     adapter.getPort(61991, port => {
         discover = new HarmonyHubDiscover(port, {address: subnet, port: 5224, interval: discoverInterval});
         discover.on(HarmonyHubDiscover.Events.ONLINE, hub => {
-
             // Triggered when a new hub was found
-            let addHub = false;
-            if (hub.friendlyName !== 'undefined' && hub.friendlyName !== undefined) {
+            if (hub.friendlyName !== undefined) {
+                let addHub = false;
+                const hubName = fixId(hub.friendlyName).replace(`.`, `_`);
+
                 if (manualDiscoverHubs.length) {
-                    for (let i = 0; i < manualDiscoverHubs.length; i++) {
-                        if (manualDiscoverHubs[i].ip === hub.ip) {
-                            adapter.log.info('[DISCOVER] Discovered ' + hub.friendlyName + ' (' + hub.ip + ')' + ' and will try to connect');
+                    for (const manualDiscoverHub of manualDiscoverHubs) {
+                        if (manualDiscoverHub.ip === hub.ip && !hubs[hubName]) {
+                            adapter.log.info(`[DISCOVER] Discovered ${hub.friendlyName} (${hub.ip}) and will try to connect`);
                             addHub = true;
-                        } else {
-                            adapter.log.debug('[DISCVOER] Discovered ' + hub.friendlyName + ' (' + hub.ip + ')' + ' but won\'t try to connect, because ' +
-                                ' manual search is configured and hub\'s ip not listed');
+                        } else if (!hubs[hubName]) {
+                            adapter.log.debug(`[DISCVOER] Discovered ${hub.friendlyName} (${hub.ip}) but won't try to connect, because \
+                            manual search is configured and hub's ip not listed`);
                         }
                     } // endFor
-                } else {
-                    adapter.log.info('[DISCOVER] Discovered ' + hub.friendlyName + ' (' + hub.ip + ')' + ' and will try to connect');
+                } else if (!hubs[hubName]) {
+                    adapter.log.info(`[DISCOVER] Discovered ${hub.friendlyName} (${hub.ip}) and will try to connect`);
                     addHub = true; // if no manual discovery --> add all hubs
                 }
-                const hubName = fixId(hub.friendlyName).replace('.', '_');
-                if (addHub && !hubs[hubName]) {
+
+                if (addHub) {
                     initHub(hubName, () => {
                         // wait 2 seconds for hub before connecting
-                        adapter.log.info('[CONNECT] Connecting to ' + hub.friendlyName + ' (' + hub.ip + ')');
+                        adapter.log.info(`[CONNECT] Connecting to ${hub.friendlyName} (${hub.ip})`);
                         connect(hubName, hub);
                     });
                 } // endIf
             } // endIf
         });
 
-        discover.on('error', err => {
-            adapter.log.warn('[DISCOVER] Discover error: ', err.message);
+        discover.on(`error`, err => {
+            adapter.log.warn(`[DISCOVER] Discover error: ${err.message}`);
         });
 
         discover.start();
-        adapter.log.info('[DISCOVER] Searching for Harmony Hubs on ' + subnet);
+        adapter.log.info(`[DISCOVER] Searching for Harmony Hubs on ${subnet}`);
     });
 } // endDiscoverStart
 
@@ -244,43 +245,43 @@ function initHub(hub, callback) {
         ioChannels: {},
         ioStates: {},
         isSync: false,
-        semaphore: require('semaphore')(1)
+        semaphore: require(`semaphore`)(1)
     };
 
-    adapter.getState(hub + '.hubConnected', (err, state) => {
+    adapter.getState(`${hub}.hubConnected`, (err, state) => {
         if (err || !state) {
-            adapter.log.debug('hub not initialized');
+            adapter.log.debug(`hub not initialized`);
             callback();
         } else {
             adapter.getChannelsOf(hub, (err, channels) => {
                 if (err || !channels) {
-                    adapter.log.debug('hub not initialized correctly');
+                    adapter.log.debug(`hub not initialized correctly`);
                     callback();
                     return;
                 }
                 for (let i = 0; i < channels.length; i++) {
                     const channel = channels[i];
-                    if (channel.common.name === 'activities') {
+                    if (channel.common.name === `activities`) {
                         hubs[hub].statesExist = true;
                         setBlocked(hub, true);
                         setConnected(hub, false);
                         hubs[hub].hasActivities = true;
-                        adapter.log.debug('hub initialized');
+                        adapter.log.debug(`hub initialized`);
                         continue;
                     }
                     hubs[hub].ioChannels[channel.common.name] = true;
                 }
-                adapter.getStates(hub + '.activities.*', (err, states) => {
+                adapter.getStates(`${hub}.activities.*`, (err, states) => {
                     if (err || !states) {
-                        adapter.log.debug('no activities found');
+                        adapter.log.debug(`no activities found`);
                         callback();
                         return;
                     }
                     for (const state in states) {
                         if (states.hasOwnProperty(state)) {
-                            const tmp = state.split('.');
+                            const tmp = state.split(`.`);
                             const name = tmp.pop();
-                            if (name !== 'currentStatus' && name !== 'currentActivity') {
+                            if (name !== `currentStatus` && name !== `currentActivity`) {
                                 hubs[hub].ioStates[name] = true;
                             }
                         }
@@ -307,21 +308,21 @@ function connect(hub, hubObj) {
     const client = new HarmonyWS(hubObj.ip);
     hubs[hub].client = client;
 
-    client.on('online', () => {
+    client.on(`online`, () => {
         setBlocked(hub, true);
         setConnected(hub, true);
-        adapter.log.info('[CONNECT] Connected to ' + hubObj.friendlyName + ' (' + hubObj.ip + ')');
+        adapter.log.info(`[CONNECT] Connected to ${hubObj.friendlyName} (${hubObj.ip})`);
         hubs[hub].client.requestConfig();
     });
 
-    client.on('offline', () => {
+    client.on(`offline`, () => {
         if (hubs[hub].connected)
-            adapter.log.info('[CONNECT] lost Connection to ' + hubObj.friendlyName + ' (' + hubObj.ip + ')');
+            adapter.log.info(`[CONNECT] lost Connection to ${hubObj.friendlyName} (${hubObj.ip})`);
         setConnected(hub, false);
         setBlocked(hub, false);
     });
 
-    client.on('config', (config) => {
+    client.on(`config`, (config) => {
         try {
             processConfig(hub, hubObj, config);
             hubs[hub].client.requestState();
@@ -330,7 +331,7 @@ function connect(hub, hubObj) {
         }
     });
 
-    client.on('state', (activityId, activityStatus) => {
+    client.on(`state`, (activityId, activityStatus) => {
         processDigest(hub, activityId, activityStatus);
     });
 }
@@ -342,11 +343,11 @@ function processConfig(hub, hubObj, config) {
         return;
     }
     /* create hub */
-    adapter.log.debug('[PROCESS] Creating activities and devices');
+    adapter.log.debug(`[PROCESS] Creating activities and devices`);
 
-    adapter.log.debug('[PROCESS] Creating hub device');
+    adapter.log.debug(`[PROCESS] Creating hub device`);
     adapter.setObject(hub, {
-        type: 'device',
+        type: `device`,
         common: {
             name: hub
         },
@@ -354,66 +355,66 @@ function processConfig(hub, hubObj, config) {
     });
 
     if (!hubs[hub].statesExist) {
-        adapter.setObject(hub + '.hubConnected', {
-            type: 'state',
+        adapter.setObject(`${hub}.hubConnected`, {
+            type: `state`,
             common: {
-                name: hub + ':hubConnected',
-                role: 'indicator.hubConnected',
-                type: 'boolean',
+                name: `${hub}:hubConnected`,
+                role: `indicator.hubConnected`,
+                type: `boolean`,
                 write: false,
                 read: true
             },
             native: {}
         });
     }
-    adapter.setState(hub + '.hubConnected', {val: true, ack: true});
+    adapter.setState(`${hub}.hubConnected`, {val: true, ack: true});
 
     if (!hubs[hub].statesExist) {
-        adapter.setObject(hub + '.hubBlocked', {
-            type: 'state',
+        adapter.setObject(`${hub}.hubBlocked`, {
+            type: `state`,
             common: {
-                name: hub + ':hubBlocked',
-                role: 'indicator.hubBlocked',
-                type: 'boolean',
+                name: `${hub}:hubBlocked`,
+                role: `indicator.hubBlocked`,
+                type: `boolean`,
                 write: false,
                 read: true
             },
             native: {}
         });
     }
-    adapter.setState(hub + '.hubBlocked', {val: true, ack: true});
+    adapter.setState(`${hub}.hubBlocked`, {val: true, ack: true});
 
     /* create activities */
-    adapter.log.debug('creating activities');
-    let channelName = hub + '.activities';
+    adapter.log.debug(`creating activities`);
+    let channelName = `${hub}.activities`;
     //create channel for activities
     adapter.setObject(channelName, {
-        type: 'channel',
+        type: `channel`,
         common: {
-            name: 'activities',
-            role: 'media.activities'
+            name: `activities`,
+            role: `media.activities`
         },
         native: {}
     });
 
     if (!hubs[hub].statesExist) {
-        adapter.setObject(channelName + '.currentActivity', {
-            type: 'state',
+        adapter.setObject(`${channelName}.currentActivity`, {
+            type: `state`,
             common: {
-                name: 'activity:currentActivity',
-                role: 'indicator.activity',
-                type: 'string',
+                name: `activity:currentActivity`,
+                role: `indicator.activity`,
+                type: `string`,
                 write: true,
                 read: true
             },
             native: {}
         });
-        adapter.setObject(channelName + '.currentStatus', {
-            type: 'state',
+        adapter.setObject(`${channelName}.currentStatus`, {
+            type: `state`,
             common: {
-                name: 'activity:currentStatus',
-                role: 'indicator.status',
-                type: 'number',
+                name: `activity:currentStatus`,
+                role: `indicator.status`,
+                type: `number`,
                 write: true,
                 read: true,
                 min: 0,
@@ -424,12 +425,12 @@ function processConfig(hub, hubObj, config) {
     }
 
     config.activity.forEach(activity => {
-        const activityLabel = fixId(activity.label).replace('.', '_');
+        const activityLabel = fixId(activity.label).replace(`.`, `_`);
         hubs[hub].activities[activity.id] = activityLabel;
         hubs[hub].activities_reverse[activityLabel] = activity.id;
-        if (activity.id === '-1') return;
+        if (activity.id === `-1`) return;
         //create activities
-        const activityChannelName = channelName + '.' + activityLabel;
+        const activityChannelName = `${channelName}.${activityLabel}`;
         //create channel for activity
         delete activity.sequences;
         delete activity.controlGroup;
@@ -437,13 +438,13 @@ function processConfig(hub, hubObj, config) {
         delete activity.rules;
         //create states for activity
         if (!hubs[hub].ioStates.hasOwnProperty(activityLabel)) {
-            adapter.log.info('[PROCESS] Added new activity: ' + activityLabel);
+            adapter.log.info(`[PROCESS] Added new activity: ${activityLabel}`);
             adapter.setObject(activityChannelName, {
-                type: 'state',
+                type: `state`,
                 common: {
-                    name: 'activity:' + activityLabel,
-                    role: 'switch',
-                    type: 'number',
+                    name: `activity:${activityLabel}`,
+                    role: `switch`,
+                    type: `number`,
                     write: true,
                     read: true,
                     min: 0,
@@ -456,23 +457,23 @@ function processConfig(hub, hubObj, config) {
     });
 
     /* create devices */
-    adapter.log.debug('[PROCESS] Creating devices');
+    adapter.log.debug(`[PROCESS] Creating devices`);
     channelName = hub;
     config.device.forEach(device => {
-        const deviceLabel = fixId(device.label).replace('.', '_');
-        const deviceChannelName = channelName + '.' + deviceLabel;
+        const deviceLabel = fixId(device.label).replace(`.`, `_`);
+        const deviceChannelName = `${channelName}.${deviceLabel}`;
         const controlGroup = device.controlGroup;
         hubs[hub].devices[device.id] = deviceLabel;
         hubs[hub].devices_reverse[deviceLabel] = device.id;
         delete device.controlGroup;
         //create channel for device
         if (!hubs[hub].ioChannels.hasOwnProperty(deviceLabel)) {
-            adapter.log.info('[PROCESS] Added new device: ' + deviceLabel);
+            adapter.log.info(`[PROCESS] Added new device: ${deviceLabel}`);
             adapter.setObject(deviceChannelName, {
-                type: 'channel',
+                type: `channel`,
                 common: {
                     name: deviceLabel,
-                    role: 'media.device'
+                    role: `media.device`
                 },
                 native: device
             });
@@ -481,36 +482,36 @@ function processConfig(hub, hubObj, config) {
                 controlGroup.function.forEach(command => {
                     command.controlGroup = groupName;
                     command.deviceId = device.id;
-                    const commandName = fixId(command.name).replace('.', '_');
+                    const commandName = fixId(command.name).replace(`.`, `_`);
                     //create command
-                    adapter.setObject(deviceChannelName + '.' + commandName, {
-                        type: 'state',
+                    adapter.setObject(`${deviceChannelName}.${commandName}`, {
+                        type: `state`,
                         common: {
-                            name: deviceLabel + ':' + commandName,
-                            role: 'button',
-                            type: 'number',
+                            name: `${deviceLabel}:${commandName}`,
+                            role: `button`,
+                            type: `number`,
                             write: true,
                             read: true,
                             min: 0
                         },
                         native: command
                     });
-                    adapter.setState(deviceChannelName + '.' + commandName, {val: '0', ack: true});
+                    adapter.setState(`${deviceChannelName}.${commandName}`, {val: `0`, ack: true});
                 });
             });
         }
         delete hubs[hub].ioChannels[deviceLabel];
     });
 
-    adapter.log.debug('[PROCESS] Deleting activities');
+    adapter.log.debug(`[PROCESS] Deleting activities`);
     Object.keys(hubs[hub].ioStates).forEach(activityLabel => {
-        adapter.log.info('[PROCESS] Removed old activity: ' + activityLabel);
-        adapter.deleteState(hub, 'activities', activityLabel);
+        adapter.log.info(`[PROCESS] Removed old activity: ${activityLabel}`);
+        adapter.deleteState(hub, `activities`, activityLabel);
     });
 
-    adapter.log.debug('[PROCESS] Deleting devices');
+    adapter.log.debug(`[PROCESS] Deleting devices`);
     Object.keys(hubs[hub].ioChannels).forEach(deviceLabel => {
-        adapter.log.info('[PROCESS] Removed old device: ' + deviceLabel);
+        adapter.log.info(`[PROCESS] Removed old device: ${deviceLabel}`);
         adapter.deleteChannel(hub, deviceLabel);
     });
 
@@ -518,7 +519,7 @@ function processConfig(hub, hubObj, config) {
     setBlocked(hub, false);
     setConnected(hub, true);
     hubs[hub].isSync = true;
-    adapter.log.info('[PROCESS] Synced hub config for ' + hubObj.friendlyName + ' (' + hubObj.ip + ')');
+    adapter.log.info(`[PROCESS] Synced hub config for ${hubObj.friendlyName} (${hubObj.ip})`);
 }
 
 function processDigest(hub, activityId, activityStatus) {
@@ -527,7 +528,7 @@ function processDigest(hub, activityId, activityStatus) {
     //Set hub status to current activity status
     setCurrentStatus(hub, activityStatus);
 
-    if (activityId !== '-1') { //if activityId is not powerOff
+    if (activityId !== `-1`) { //if activityId is not powerOff
         //set activityId's status
         setStatusFromActivityID(hub, activityId, activityStatus);
 
@@ -551,32 +552,32 @@ function processDigest(hub, activityId, activityStatus) {
 
 function setCurrentActivity(hub, id) {
     if (!hubs[hub].activities.hasOwnProperty(id)) {
-        adapter.log.debug('[SETACTIVITY] Unknown activityId: ' + id);
+        adapter.log.debug(`[SETACTIVITY] Unknown activityId: ${id}`);
         return;
     }
-    adapter.log.debug('current activity: ' + hubs[hub].activities[id]);
-    adapter.setState(hub + '.activities.currentActivity', {val: hubs[hub].activities[id], ack: true});
+    adapter.log.debug(`current activity: ${hubs[hub].activities[id]}`);
+    adapter.setState(`${hub}.activities.currentActivity`, {val: hubs[hub].activities[id], ack: true});
 }
 
 function setCurrentStatus(hub, status) {
     if (hubs[hub].statesExist)
-        adapter.setState(hub + '.activities.currentStatus', {val: status, ack: true});
+        adapter.setState(`${hub}.activities.currentStatus`, {val: status, ack: true});
 }
 
 function setStatusFromActivityID(hub, id, value) {
-    if (id === '-1') return;
+    if (id === `-1`) return;
     if (!hubs[hub].activities.hasOwnProperty(id)) {
-        adapter.log.warn('[SETSTATE] Unknown activityId: ' + id);
+        adapter.log.warn(`[SETSTATE] Unknown activityId: ${id}`);
         return;
     }
-    const channelName = fixId(hub + '.activities.' + hubs[hub].activities[id]);
+    const channelName = fixId( `${hub}.activities.${hubs[hub].activities[id]}`);
     adapter.setState(channelName, {val: value, ack: true});
 }
 
 function setBlocked(hub, bool) {
     if (hubs[hub] && hubs[hub].statesExist) {
         bool = Boolean(bool);
-        adapter.setState(hub + '.hubBlocked', {val: bool, ack: true});
+        adapter.setState(`${hub}.hubBlocked`, {val: bool, ack: true});
         hubs[hub].blocked = bool;
     }
 }
@@ -585,7 +586,7 @@ function setConnected(hub, bool) {
     if (hubs[hub] && hubs[hub].statesExist) {
         bool = Boolean(bool);
         hubs[hub].connected = bool;
-        adapter.setState(hub + '.hubConnected', {val: bool, ack: true});
+        adapter.setState(`${hub}.hubConnected`, {val: bool, ack: true});
     }
 }
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "harmony",
-        "version": "1.2.1",
+        "version": "1.2.2",
         "title": "Logitech Harmony",
         "desc": {
             "en": "Control your harmony activities from ioBroker",
@@ -12,6 +12,18 @@
             "Pmant <patrickmo@gmx.de>"
         ],
         "news": {
+            "1.2.2": {
+                "en": "reduce discover interval and only log new discovered hubs",
+                "de": "Reduzieren des Erkennungsintervall und logge nur neu entdeckte Hubs",
+                "ru": "сократить интервал обнаружения и регистрировать только новые обнаруженные концентраторы",
+                "pt": "reduza o intervalo de descoberta e registre somente novos hubs descobertos",
+                "nl": "verminder het ontdekkingsinterval en registreer alleen nieuw ontdekte hubs",
+                "fr": "réduire l'intervalle de découverte et ne consigner que les nouveaux concentrateurs découverts",
+                "it": "ridurre l'intervallo di rilevamento e registrare solo i nuovi hub rilevati",
+                "es": "reducir el intervalo de descubrimiento y solo registrar nuevos concentradores descubiertos",
+                "pl": "zmniejsz interwał wykrywania i rejestruj tylko odkryte nowe koncentratory",
+                "zh-cn": "减少发现间隔并仅记录新发现的集线器"
+            },
             "1.2.1": {
                 "en": "at least version 1.0.5 of harmonyhubws is used",
                 "de": "Es wird mindestens Version 1.0.5 von harmonyhubws verwendet",
@@ -79,21 +91,6 @@
                 "en": "fix problematic chars",
                 "de": "Fix für problemantische Zeichen",
                 "ru": "fix problematic chars"
-            },
-            "0.7.1": {
-                "en": "bug fixes",
-                "de": "bug fixes",
-                "ru": "bug fixes"
-            },
-            "0.7.0": {
-                "en": "support multiple hubs",
-                "de": "Unterstützung für mehrere Hubs hinzugefügt",
-                "ru": "support multiple hubs"
-            },
-            "0.6.2": {
-                "en": "fix wrong port",
-                "de": "falscher Port korrigiert",
-                "ru": "fix wrong port"
             }
         },
         "license": "MIT",
@@ -122,7 +119,7 @@
         "password": "default",
         "subnet": "255.255.255.255",
         "devices": [],
-        "discoverInterval": 1000
+        "discoverInterval": 10000
     },
     "objects": []
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iobroker.harmony",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "engines": {
         "node": ">=6.0.0"
     },

--- a/tasks/jscs.js
+++ b/tasks/jscs.js
@@ -1,17 +1,17 @@
-var srcDir   = __dirname + '/../';
+const srcDir   = __dirname + `/../`;
 
 module.exports = {
     all: {
         src: [
-                srcDir + '*.js',
-                srcDir + 'lib/*.js',
-                srcDir + 'adapter/example/*.js',
-                srcDir + 'tasks/**/*.js',
-                srcDir + 'www/**/*.js',
-                '!' + srcDir + 'www/lib/**/*.js',
-                '!' + srcDir + 'node_modules/**/*.js',
-                '!' + srcDir + 'adapter/*/node_modules/**/*.js'
+            srcDir + `*.js`,
+            srcDir + `lib/*.js`,
+            srcDir + `adapter/example/*.js`,
+            srcDir + `tasks/**/*.js`,
+            srcDir + `www/**/*.js`,
+            `!` + srcDir + `www/lib/**/*.js`,
+            `!` + srcDir + `node_modules/**/*.js`,
+            `!` + srcDir + `adapter/*/node_modules/**/*.js`
         ],
-        options: require('./jscsRules.js')
+        options: require(`./jscsRules.js`)
     }
 };

--- a/tasks/jscsRules.js
+++ b/tasks/jscsRules.js
@@ -1,7 +1,7 @@
 module.exports = {
     force: true,
-    "requireCurlyBraces": ["else", "for", "while", "do", "try", "catch"], /*"if",*/
-    "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
+    "requireCurlyBraces": [`else`, `for`, `while`, `do`, `try`, `catch`], /*"if",*/
+    "requireSpaceAfterKeywords": [`if`, `else`, `for`, `while`, `do`, `switch`, `return`, `try`, `catch`],
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "disallowSpacesInFunctionDeclaration": {"beforeOpeningRoundBrace": true},
@@ -19,18 +19,18 @@ module.exports = {
     "disallowSpacesInsideParentheses": true,
     "requireCommaBeforeLineBreak": true,
     //"requireAlignedObjectValues": "all",
-    "requireOperatorBeforeLineBreak": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-//            "disallowLeftStickedOperators": ["?", "+", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-//                    "requireRightStickedOperators": ["!"],
-//                    "requireSpaceAfterBinaryOperators": ["?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    "requireOperatorBeforeLineBreak": [`?`, `+`, `-`, `/`, `*`, `=`, `==`, `===`, `!=`, `!==`, `>`, `>=`, `<`, `<=`],
+    //            "disallowLeftStickedOperators": ["?", "+", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    //                    "requireRightStickedOperators": ["!"],
+    //                    "requireSpaceAfterBinaryOperators": ["?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
     //"disallowSpaceAfterBinaryOperators": [","],
-    "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
-    "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
-    "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
-    "requireSpaceAfterBinaryOperators": ["?", ">", ",", ">=", "<=", "<", "+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+    "disallowSpaceAfterPrefixUnaryOperators": [`++`, `--`, `+`, `-`, `~`, `!`],
+    "disallowSpaceBeforePostfixUnaryOperators": [`++`, `--`],
+    "requireSpaceBeforeBinaryOperators": [`+`, `-`, `/`, `*`, `=`, `==`, `===`, `!=`, `!==`],
+    "requireSpaceAfterBinaryOperators": [`?`, `>`, `,`, `>=`, `<=`, `<`, `+`, `-`, `/`, `*`, `=`, `==`, `===`, `!=`, `!==`],
     //"validateIndentation": 4,
     //"validateQuoteMarks": { "mark": "\"", "escape": true },
     "disallowMixedSpacesAndTabs": true,
-    "disallowKeywordsOnNewLine": ["else", "catch"]
+    "disallowKeywordsOnNewLine": [`else`, `catch`]
 
 };

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -1,17 +1,17 @@
-var srcDir   = __dirname + '/../';
+const srcDir   = __dirname + `/../`;
 
 module.exports = {
     options: {
         force: true
     },
     all: [
-        srcDir + '*.js',
-        srcDir + 'lib/*.js',
-        srcDir + 'adapter/example/*.js',
-        srcDir + 'tasks/**/*.js',
-        srcDir + 'www/**/*.js',
-        '!' + srcDir + 'www/lib/**/*.js',
-        '!' + srcDir + 'node_modules/**/*.js',
-        '!' + srcDir + 'adapter/*/node_modules/**/*.js'
+        srcDir + `*.js`,
+        srcDir + `lib/*.js`,
+        srcDir + `adapter/example/*.js`,
+        srcDir + `tasks/**/*.js`,
+        srcDir + `www/**/*.js`,
+        `!` + srcDir + `www/lib/**/*.js`,
+        `!` + srcDir + `node_modules/**/*.js`,
+        `!` + srcDir + `adapter/*/node_modules/**/*.js`
     ]
 };


### PR DESCRIPTION
- due to the new connection handling it could happen that discover module has lost and triggered new online for hub, while our new connection handling did not lose the hub at all, thus it was logged `discoverd hub xy`, now this will only be logged if the hub is not active yet
- reduced discover interval from 1s to 10s, because of new connection handling we dont need to spam the hub that much
- and use template literals whenever possible - imho this offers the best readable strings without having so much concatenations, which usually makes strings hard to read in the code
